### PR TITLE
export duplicate asset name: Rename instead of failing

### DIFF
--- a/plugins/figma/src/interface/utils/project/create.ts
+++ b/plugins/figma/src/interface/utils/project/create.ts
@@ -63,13 +63,18 @@ export async function create(
   // Assets
   if (release.includeAssets) {
     const added = new Set();
+    let duplicates = 0;
     for (const [name, isVector, bytes] of project.assets) {
       const ext = isVector ? 'svg' : 'png';
       const type = isVector ? 'svg' : 'img';
       const mime = isVector ? 'image/svg+xml' : 'image/png';
       const blob = new Blob([bytes], {type: mime});
-      const path = `assets/${type}/${name.toLowerCase()}.${ext}`;
-      if (added.has(path)) return;
+      let path = `assets/${type}/${name.toLowerCase()}.${ext}`;
+      //if (added.has(path)) return;
+      if (added.has(path)) { // export duplicate asset name: Rename instead of failing
+        console.warn(`>>> Asset already exists: ${path}`); // todo show warning in UI
+        path = `assets/${type}/${name.toLowerCase()}__DUPLICATE_NAME_${++duplicates}.${ext}`;
+      }      
       const category = design.getChildByName(`assets/${type}`);
       if (category) zip.remove(category);
       design.addBlob(path, blob);

--- a/plugins/figma/src/interface/utils/project/data/metadata.ts
+++ b/plugins/figma/src/interface/utils/project/data/metadata.ts
@@ -31,6 +31,8 @@ export function localesConfig(info: ProjectInfo): string {
     '',
     'export type Locales = keyof typeof locales;',
     `export const sourceLocale: Locales = "${info.locales.source}";`,
+    // fix info.locales.all can be undefined: `export const locales = ${JSON.stringify(info.locales.all.reduce((acc, [key, value]) => {
+    !info.locales.all ? `export const locales = []; // patch for undefined: info.locales.all` : // patch undefined: info.locales.all
     `export const locales = ${JSON.stringify(info.locales.all.reduce((acc, [key, value]) => {
       acc[key] = value;
       return acc;


### PR DESCRIPTION
Export fails if an asset has a duplicate name. Designers tend to have tons of duplicate names...